### PR TITLE
use default app namespace

### DIFF
--- a/i18n/es.po
+++ b/i18n/es.po
@@ -9,7 +9,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 msgid "Select Dashboard"
-msgstr ""
+msgstr "Seleccionar panel"
 
 msgid "Select Month"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "eject": "react-scripts eject",
         "prettify": "prettier \"./**/*.{js,jsx,json,css,ts,tsx}\" --write",
         "extract-pot": "yarn d2-i18n-extract -p src/ -o i18n/",
-        "localize": "yarn update-po && d2-i18n-generate -n dhis2-skeleton-app -p ./i18n/ -o ./src/locales/",
+        "localize": "yarn update-po && d2-i18n-generate -n dashboard-reports -p ./i18n/ -o ./src/locales/",
         "update-po": "yarn extract-pot && find i18n/ -name '*.po' -exec msgmerge --backup=off -U {} i18n/en.pot \\;",
         "manifest": "d2-manifest package.json build/manifest.webapp",
         "cy:verify": "cypress verify",

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1,4 +1,5 @@
 declare module "@dhis2/d2-i18n" {
     export function t(value: string, namespace?: object): string;
     export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
 }

--- a/src/webapp/contexts/app-context.ts
+++ b/src/webapp/contexts/app-context.ts
@@ -3,6 +3,7 @@ import { CompositionRoot } from "../../CompositionRoot";
 import { Settings } from "../../domain/entities/Settings";
 import { User } from "../../domain/entities/User";
 import { D2Api } from "../../types/d2-api";
+import i18n from "../../locales";
 
 export interface AppContextState {
     api: D2Api;
@@ -17,6 +18,7 @@ export const AppContext = React.createContext<AppContextState | null>(null);
 
 export function useAppContext() {
     const context = useContext(AppContext);
+    i18n.setDefaultNamespace("dashboard-reports");
     if (context) {
         return context;
     } else {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694ubx3x

### :memo: Implementation
- [x] Update i18n types
- [x] Set default namespace in `app-context.ts`

### :art: Screenshots
<img width="563" alt="Screenshot 2024-06-25 at 19 48 06" src="https://github.com/EyeSeeTea/dashboard-reports/assets/37223065/ade41158-fd01-4eb1-bdb2-1d372376e292">

### :fire: Testing
I added a translation for `Select Dashboard` to test

#8694ubx3x