### PR TITLE
add shortname for constant

### DIFF
--- a/src/data/repositories/SettingsD2ConstantRepository.ts
+++ b/src/data/repositories/SettingsD2ConstantRepository.ts
@@ -38,13 +38,15 @@ export class SettingsD2ConstantRepository implements SettingsRepository {
     }
 
     public save(settings: Settings): FutureData<void> {
+        const name = "Dashboard Reports Storage";
         return runMetadata(
             this.api.metadata.post({
                 constants: [
                     {
                         id: settings.id ? settings.id : getUid("settings"),
                         code: SETTINGS_CODE,
-                        name: "Dashboard Reports Storage",
+                        name,
+                        shortName: name,
                         description: JSON.stringify(
                             {
                                 fontSize: settings.fontSize,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #? I was adding constant support in [user-extended](https://github.com/EyeSeeTea/user-extended-app/pull/312) and I noticed this change in v40 so there's no task for this PR

### :memo: Implementation

- `shortName` was not a mandatory field for constants until v39. Starting v40 now this field is required so in this PR I'm including the field when storage mode is set to `constants`.

https://play.im.dhis2.org/stable-2-39-8/dhis-web-maintenance/index.html#/edit/otherSection/constant/add (shortname not mandatory)

https://play.im.dhis2.org/stable-2-40-7/dhis-web-maintenance/index.html#/edit/otherSection/constant/add (shortname is required)

### :art: Screenshots

### :fire: Testing
