### PR TITLE
fix: load eventChart and eventReport for v2.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "dashboard-reports",
     "description": "Dashboard Reports",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/data/repositories/DashboardD2Repository.ts
+++ b/src/data/repositories/DashboardD2Repository.ts
@@ -1,4 +1,4 @@
-import { Dashboard } from "../../domain/entities/Dashboard";
+import { Dashboard, DashboardItem, LegacyReportType } from "../../domain/entities/Dashboard";
 import { FutureData } from "../../domain/entities/Future";
 import { DashboardRepository } from "../../domain/repositories/DashboardRepository";
 import { D2Api, MetadataPick } from "../../types/d2-api";
@@ -23,10 +23,106 @@ export class DashboardD2Repository implements DashboardRepository {
         return new Dashboard({
             id: d2Dashboard.id,
             name: d2Dashboard.name,
-            dashboardItems: d2Dashboard.dashboardItems,
+            dashboardItems: d2Dashboard.dashboardItems
+                .map(DashboardItemMapper.transformLegacyDashboardItem)
+                .filter(DashboardItemMapper.hasVisualizationData)
+                .map(DashboardItemMapper.map),
         });
     }
 }
+
+class DashboardItemMapper {
+    /**
+     * Convert legacy eventChart and eventReport fields to the new eventVisualization field
+     */
+    static transformLegacyDashboardItem(d2DashboardItem: D2DashboardItemWithLegacy): D2DashboardItem {
+        const { eventChart, eventReport, ...otherProps } = d2DashboardItem;
+        const legacyVisualization = eventChart || eventReport;
+        if (legacyVisualization) {
+            return {
+                ...otherProps,
+                eventVisualization: { ...legacyVisualization },
+            };
+        }
+        return d2DashboardItem;
+    }
+
+    static hasVisualizationData(dashboardItem: D2DashboardItem): boolean {
+        return Boolean(dashboardItem.visualization || dashboardItem.map || dashboardItem.eventVisualization);
+    }
+
+    static map(dashboardItem: D2DashboardItem): DashboardItem {
+        return {
+            ...dashboardItem,
+            elementId: dashboardItem.id,
+            width: dashboardItem.width,
+            height: dashboardItem.height,
+            reportTitle: DashboardItemMapper.getItemTitle(dashboardItem),
+            reportId: DashboardItemMapper.getItemReportId(dashboardItem),
+            useLegacy: DashboardItemMapper.getItemShouldUseLegacy(dashboardItem),
+            legacyReportType: DashboardItemMapper.getItemLegacyReportType(dashboardItem),
+        };
+    }
+
+    /**
+     * @returns true when Legacy Plugin is preferred.
+     */
+    private static getItemShouldUseLegacy(dashboardItem: D2DashboardItem): boolean {
+        return (
+            // EVENT_CHART is not working with the new dhis-data-visualizer iframe
+            dashboardItem.type === "EVENT_CHART" ||
+            // EVENT_REPORT only works with the line-listing iframe
+            (dashboardItem.type === "EVENT_REPORT" && dashboardItem.eventVisualization?.type !== "LINE_LIST")
+        );
+    }
+
+    private static getItemData(dashboardItem: D2DashboardItem) {
+        const data = dashboardItem.map ?? dashboardItem.eventVisualization ?? dashboardItem.visualization;
+        if (!data) {
+            throw new Error(
+                `Dashboard item (id: ${dashboardItem.id}, type: ${dashboardItem.type}) is missing required property - one of: map, eventVisualization, visualization`
+            );
+        }
+        return data;
+    }
+
+    private static getItemTitle(dashboardItem: D2DashboardItem): string {
+        return DashboardItemMapper.getItemData(dashboardItem).name.trim();
+    }
+
+    private static getItemReportId(dashboardItem: D2DashboardItem): string {
+        return DashboardItemMapper.getItemData(dashboardItem).id;
+    }
+
+    private static getItemLegacyReportType(dashboardItem: D2DashboardItem): LegacyReportType | null {
+        if (dashboardItem.type === "EVENT_CHART") {
+            return "eventChartPlugin";
+        } else if (dashboardItem.type === "EVENT_REPORT") {
+            return "eventReportPlugin";
+        }
+        return null;
+    }
+}
+
+const dashboardItemLegacyFields = {
+    // eventChart and eventReport are legacy fields available in <=2.40
+    // removed in 2.41+ and included in eventVisualization instead
+    eventChart: {
+        id: true,
+        name: true,
+        type: true,
+    },
+    eventReport: {
+        id: true,
+        name: true,
+        type: true,
+    },
+} as const;
+
+type D2DashboardItemLegacyFields = {
+    eventChart?: { id: string; name: string; type: string };
+    eventReport?: { id: string; name: string; type: string };
+};
 
 const dashboardFields = {
     id: true,
@@ -59,7 +155,19 @@ const dashboardFields = {
             name: true,
         },
         type: true,
+        ...dashboardItemLegacyFields,
     },
 } as const;
 
 type D2Dashboard = MetadataPick<{ dashboards: { fields: typeof dashboardFields } }>["dashboards"][number];
+
+type D2DashboardItem = Omit<
+    MetadataPick<{
+        dashboardItems: { fields: typeof dashboardFields["dashboardItems"] };
+    }>["dashboardItems"][number] & {
+        eventVisualization?: { id: string; name: string; type: string };
+    },
+    keyof typeof dashboardItemLegacyFields
+>;
+
+type D2DashboardItemWithLegacy = D2DashboardItem & D2DashboardItemLegacyFields;

--- a/src/domain/entities/Dashboard.ts
+++ b/src/domain/entities/Dashboard.ts
@@ -45,69 +45,9 @@ export class Dashboard {
         this.name = data.name;
 
         this.dashboardItems = _(data.dashboardItems)
-            .filter(dashboardItem => this.showInDashboard(dashboardItem))
-            .map(dashboardItem => {
-                return {
-                    ...this.getReportInformation(dashboardItem),
-                    elementId: dashboardItem.id,
-                    width: dashboardItem.width,
-                    height: dashboardItem.height,
-                };
-            })
             .uniqBy("reportId")
             .sortBy(dashboard => dashboard.reportTitle)
             .value();
-    }
-
-    private showInDashboard(dashboardItem: DashboardItem): boolean {
-        return Boolean(dashboardItem.visualization || dashboardItem.map || dashboardItem.eventVisualization);
-    }
-
-    private getReportInformation(dashboardItem: DashboardItem): DashboardItem {
-        return {
-            ...dashboardItem,
-            reportTitle: this.getItemTitle(dashboardItem),
-            reportId: this.getItemReportId(dashboardItem),
-            useLegacy: this.getItemShouldUseLegacy(dashboardItem),
-            legacyReportType: this.getItemLegacyReportType(dashboardItem),
-        };
-    }
-
-    /**
-     * @returns true when Legacy Plugin is preferred.
-     */
-    private getItemShouldUseLegacy(dashboardItem: DashboardItem): boolean {
-        return (
-            // EVENT_CHART is not working with the new dhis-data-visualizer iframe
-            dashboardItem.type === "EVENT_CHART" ||
-            // EVENT_REPORT only works with the line-listing iframe
-            (dashboardItem.type === "EVENT_REPORT" && dashboardItem.eventVisualization?.type !== "LINE_LIST")
-        );
-    }
-
-    private getItemData(dashboardItem: DashboardItem) {
-        const data = dashboardItem.map ?? dashboardItem.eventVisualization ?? dashboardItem.visualization;
-        if (!data) {
-            throw new Error("Missing property - one of: map, eventVisualization, visualization");
-        }
-        return data;
-    }
-
-    private getItemTitle(dashboardItem: DashboardItem): string {
-        return this.getItemData(dashboardItem).name.trim();
-    }
-
-    private getItemReportId(dashboardItem: DashboardItem): string {
-        return this.getItemData(dashboardItem).id;
-    }
-
-    private getItemLegacyReportType(dashboardItem: DashboardItem): LegacyReportType | null {
-        if (dashboardItem.type === "EVENT_CHART") {
-            return "eventChartPlugin";
-        } else if (dashboardItem.type === "EVENT_REPORT") {
-            return "eventReportPlugin";
-        }
-        return null;
     }
 }
 

--- a/src/webapp/hooks/useLegacyVisualizationPlugin.ts
+++ b/src/webapp/hooks/useLegacyVisualizationPlugin.ts
@@ -19,7 +19,7 @@ export function useLegacyVisualizationPlugin(dashboardItem: DashboardItem, visua
                 return;
             }
             // legacy js plugins require ExtJS
-            const DEPENDENCIES = ["/js/ext-all.min.js"];
+            const DEPENDENCIES = ["./js/ext-all.min.js"];
             try {
                 await Promise.all(DEPENDENCIES.map(dep => loadJsPlugin(dep)));
                 await loadJsPlugin(pluginFileName);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869a1v88m

### :memo: Implementation

- fix: from `dashboardItems`, load `eventChart` and `eventReport` (available in api <=2.40)
- remap these to `eventVisualization`, as expected in >=v2.41
- refactor: move dashboardItem data mappings from business layer to data layer, to `DashboardItemMapper`. Improve typings

### :art: Screenshots

### :fire: Testing
